### PR TITLE
:+1: VoiceOverでもラベルがないと困るのを実感できるようにする

### DIFF
--- a/src/components/examples/form/Annotation.tsx
+++ b/src/components/examples/form/Annotation.tsx
@@ -13,9 +13,9 @@ export const AnnotationPassword = (): JSX.Element => (
       <FormItem>
         <label>
           <FormLabel>パスワード</FormLabel>
-          <TextField type="password" />
+          <TextField type="password" aria-describedby="annotaiton-password" />
         </label>
-        <FormAnnotation>8文字以上の英数字で入力してください</FormAnnotation>
+        <FormAnnotation id="annotaiton-password">8文字以上の英数字で入力してください</FormAnnotation>
       </FormItem>
     </form>
   </ExampleContainer>
@@ -31,9 +31,9 @@ export const AnnotationCompany = (): JSX.Element => (
       <FormItem>
         <label>
           <FormLabel>会社名</FormLabel>
-          <TextField type="text" />
+          <TextField type="text" aria-describedby="annotation-company" />
         </label>
-        <FormAnnotation>記入例: freee株式会社</FormAnnotation>
+        <FormAnnotation id="annotation-company" >記入例: freee株式会社</FormAnnotation>
       </FormItem>
     </form>
   </ExampleContainer>

--- a/src/components/parts/CheckBox.tsx
+++ b/src/components/parts/CheckBox.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const CheckBoxWrapper = styled.span`
-  display: inline-block;
+const CheckBoxWrapper = styled.div`
+  display: inline-flex;
   margin-right: 1rem;
-`;
-const CheckBoxInput = styled.input`
-  margin-right: 0.5rem;
+  gap: 0.5rem;
 `;
 
 export const CheckBox = ({
@@ -21,7 +19,7 @@ export const CheckBox = ({
   onChange?: React.ChangeEventHandler;
 }): JSX.Element => (
   <CheckBoxWrapper>
-    <CheckBoxInput type="checkbox" {...props} />
-    {children}
+    <input type="checkbox" {...props} />
+    <div>{children}</div>
   </CheckBoxWrapper>
 );

--- a/src/components/parts/FormLabel.ts
+++ b/src/components/parts/FormLabel.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const FormLabel = styled.span`
+export const FormLabel = styled.div`
   display: block;
   font-size: 0.875rem;
   margin-bottom: 0.25rem;

--- a/src/components/parts/RadioButton.tsx
+++ b/src/components/parts/RadioButton.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 const RadioButtonWrapper = styled.span`
-  display: inline-block;
+  display: inline-flex;
   margin-right: 1rem;
-`;
-const RadioButtonInput = styled.input`
-  margin-right: 0.5rem;
+  gap: 0.5rem
 `;
 
 export const RadioButton = ({
@@ -21,7 +19,7 @@ export const RadioButton = ({
   id?: string;
 }): JSX.Element => (
   <RadioButtonWrapper>
-    <RadioButtonInput type="radio" name={name} value={value} id={id} />
-    {children}
+    <input type="radio" name={name} value={value} id={id} />
+    <div>{children}</div>
   </RadioButtonWrapper>
 );


### PR DESCRIPTION
macOS (monterey) のVoiceOverは span 要素と input の連続を適切にラベル付けされているように読んでしまうようなので、ラベル（らしき）部分がdiv要素になるようにした。
これによってラベルは推測されず、VoiceOver使用時に何のフィールドなのかわからなくなり、悪い例の悪さを実感できる。

また、注釈をつけている場所にaria-describedbyを追加した。良い例はなるべく良くしたい。